### PR TITLE
1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/eslint-config",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/eslint-config",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Our standard lint configurations for JavaScript",
   "main": ".eslintrc.json",
   "scripts": {


### PR DESCRIPTION
依存パッケージのアップデートを実施する。
特に `eslint-config-standard` は `eslint@>=6.2.2` にアップデートされることで、ES2020に対応してBigIntとDynamicImportをサポートするので、これを `1.1.0` としてリリースする。

- [x] `eslint-config-standard`: #12 
- [x] `eslint-config-prettier`: #13 
