### PR TITLE
許可するグロバール変数の環境を設定する

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,10 @@
 {
+  "env": {
+    "es2020": true,
+    "browser": true,
+    "jest": true,
+    "node": true
+  },
   "extends": [
     "standard",
     "plugin:@typescript-eslint/recommended",


### PR DESCRIPTION
#18 

`env` オプションで以下の環境を有効化しました。
今後のプロジェクトで使うにはこれぐらいは設定しておいても良いかなと思いましたがいかがでしょうか。

- `es2020`
- `browser`
- `jest`
- `node`

公式ドキュメント→ https://eslint.org/docs/user-guide/configuring#specifying-environments