### PR TITLE
non-null-assertion を許可する

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,5 +8,8 @@
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "sourceType": "module"
+  },
+  "rules": {
+    "@typescript-eslint/no-non-null-assertion": "off"
   }
 }


### PR DESCRIPTION
#18 

[@typescript-eslint/recommended](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules) では non-null-assertion が許可されていないが、さすがに辛くね？ということでルールを上書きしたいです。
いかがでしょうか？
