### PR TITLE
2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/eslint-config",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -41,16 +41,6 @@
         "eslint-scope": "^5.0.0"
       }
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz",
-      "integrity": "sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==",
-      "requires": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.10.0",
-        "eslint-scope": "^5.0.0"
-      }
-    },
     "@typescript-eslint/parser": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.10.0.tgz",
@@ -60,20 +50,6 @@
         "@typescript-eslint/experimental-utils": "2.10.0",
         "@typescript-eslint/typescript-estree": "2.10.0",
         "eslint-visitor-keys": "^1.1.0"
-      }
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz",
-      "integrity": "sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==",
-      "requires": {
-        "debug": "^4.1.1",
-        "eslint-visitor-keys": "^1.1.0",
-        "glob": "^7.1.6",
-        "is-glob": "^4.0.1",
-        "lodash.unescape": "4.0.1",
-        "semver": "^6.3.0",
-        "tsutils": "^3.17.1"
       }
     },
     "@typescript-eslint/typescript-estree": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/eslint-config",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Our standard lint configurations for JavaScript",
   "main": ".eslintrc.json",
   "scripts": {


### PR DESCRIPTION
`@typescript-eslint/*` にいくつかバグフィックスが入ったので、[dependencies](https://github.com/maboroshi-inc/eslint-config/labels/dependencies) PRをまとめてパッチアップデートとしてリリースします。

- [x] #36 
- [x] #37 
- [x] バージョン番号の設定
