### PR TITLE
dependabot.yaml を改修する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     timezone: Asia/Tokyo
   open-pull-requests-limit: 10
   reviewers:
-  - haribote
   - isoden
   - oti
   allow:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,4 @@ updates:
   - oti
   allow:
   - dependency-type: production
-  ignore:
-  - dependency-name: eslint-config-prettier
-    versions:
-    - 8.0.0
-    - 8.1.0
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
   reviewers:
   - haribote
   - isoden
-  - NaokiMatsuda
   - oti
   allow:
   - dependency-type: production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           node-version-file: '.node-version'
           registry-url: https://registry.npmjs.org/
       - name: npm install
-        run: npm ci
+        run: npm ci --legacy-peer-deps
         env:
           CI: true
       - name: npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maboroshi/eslint-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maboroshi/eslint-config",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@maboroshi/prettier-config": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/eslint-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Our standard lint configurations for JavaScript",
   "main": ".eslintrc.json",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/maboroshi-inc/eslint-config#readme",
   "dependencies": {
     "@maboroshi/prettier-config": "^1.0.0",
-    "@typescript-eslint/eslint-plugin": "^2.24.0",
+    "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.6.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard": "^17.1.0",


### PR DESCRIPTION
- [x] レビュアーの調整
- [x] ignore フィールドの調整

`haribote` と `NaokiMatsuda` を reviewers からトルツメしました。

ignore に設定されていた eslint-config-prettier は[すでに v9 を使っている](https://github.com/maboroshi-inc/eslint-config/blob/master/package.json#L23)のでこのフィールドもトルツメしています。

確認お願いいたします。
